### PR TITLE
Fix some number fields

### DIFF
--- a/mfish.bib
+++ b/mfish.bib
@@ -3967,9 +3967,9 @@
 		  (Crustacea Thalassinidea)}",
   author	= "C. E. Devine",
   journal	= "{Transactions of the Royal Society of New Zealand}",
-  volume	= "{8}",
-  pages		= "{93--110}",
-  year		= "{1966}"
+  volume	= "8",
+  pages		= "93--110",
+  year		= "1966"
 }
 
 @Article{	  dia_gazette_2006,
@@ -6277,9 +6277,9 @@
 		  whales during fishing operations in central Chile}",
   author	= "L. H{\"u}ckst{\"a}dt and T. Antezana",
   journal	= "{Scientia Marina}",
-  volume	= "{68}",
-  number	= "{2}",
-  pages		= "{295--298}",
+  volume	= "68",
+  number	= "2",
+  pages		= "295--298",
   year		= "2004"
 }
 
@@ -10434,7 +10434,7 @@
   title		= "{Estimated capture of seabirds in {New} {Zealand} trawl
 		  and longline fisheries, 2002--03 to 2011--12}",
   author	= "Y. Richard and E. R. Abraham",
-  year		= "{2013}",
+  year		= "2013",
   note		= "{Draft Aquatic Environment and Biodiversity Report}"
 }
 
@@ -12172,7 +12172,7 @@
 		  A. Jackson and F. Mour{\~a}o and S. Wells and C. S. Baker",
   journal	= "{Marine Mammal Science}",
   volume	= "29",
-  year		= "{2013}",
+  year		= "2013",
   pages		= "E390--E410"
 }
 


### PR DESCRIPTION
`s/"{(\d+)}"/"$1"/` in some entries because the Pandoc parser doesn't handle the
former format in the same way as BibTeX.
