### PR TITLE
Remove duplicate for `bell_breeding_2022`; fix invalid year for `middleton_kahawai_inprep`

### DIFF
--- a/dragonfly.bib
+++ b/dragonfly.bib
@@ -737,13 +737,6 @@ author = {D. Klehr and J. Stoffels and A. Hill and V.-D. Pham and S. {van der Li
   year = {2024}
 }
 
-@Unpublished{ bell_breeding_2022,
-	title = "{Breeding population assessment of kawau p{\=a}teketeke/New Zealand king shag in the Marlborough Sounds: 2021 breeding season}",
-	author = {M. Bell and P. Frost and R. Schuckard},
-	year = {2022},
-	addendum = "{Unpublished client report for Marine Species Team, Biodiversity Group, Department of Conservation, Wellington.}"
-}
-
 @Article{ brown_dive_2001,
 author = {D, Brown},
 year = {2001},
@@ -23777,7 +23770,7 @@ on the 2021 SNA 8 stock assessment}",
 @Unpublished{	  middleton_kahawai_inprep,
   title		= "{The Kahawai database}",
   author	= "D. A. J. Middleton",
-  year		= "in prep."
+  note		= "In preparation"
 }
 
 @Misc{		  middleton_managing_2012,


### PR DESCRIPTION
Minor fixes I had to make to allow Stencila CLI (which uses [`hayagriva`](https://github.com/typst/hayagriva/) under the hood) to parse `dragonfly.bib` so it could be used to render a DOCX for the https://github.com/dragonfly-science/TUR-remote-sensing-validation/ project. Without these fixes `hayagriva` errors while parsing this bibliography.